### PR TITLE
fix indentation in zome code template

### DIFF
--- a/code/src/lib.rs
+++ b/code/src/lib.rs
@@ -53,7 +53,7 @@ mod my_zome {
     }
 
     #[entry_def]
-     fn my_entry_def() -> ValidatingEntryType {
+    fn my_entry_def() -> ValidatingEntryType {
         entry!(
             name: "my_entry",
             description: "this is a same entry defintion",


### PR DESCRIPTION
I've noticed this one every single time I generated a rust-proc zome... figured I'd fix it myself.